### PR TITLE
Remove Flattr from mentioned Bitcoin accepting merchants

### DIFF
--- a/_templates/download.html
+++ b/_templates/download.html
@@ -16,7 +16,7 @@ lin32: "linux32.tar.gz"
 lin64: "linux64.tar.gz"
 
 ---
-{% capture PATH_PREFIX %}/bin/{{ site.DOWNLOAD_VERSION }}{% endcapture %}
+{% capture PATH_PREFIX %}/bin/bitcoin-core-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{ site.DOWNLOAD_VERSION }}{% endcapture %}
 <link rel="alternate" type="application/rss+xml" href="/en/rss/releases.rss" title="Bitcoin Core releases">
 <div class="download">

--- a/_templates/download.html
+++ b/_templates/download.html
@@ -71,7 +71,7 @@ lin64: "linux64.tar.gz"
       </div>
     </div>
     <p>
-      <a href="/bin/{{ site.DOWNLOAD_VERSION }}/SHA256SUMS.asc">{% translate downloadsig %}</a><br>
+      <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">{% translate downloadsig %}</a><br>
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent">{% translate downloadtorrent %}</a>{% if site.DOWNLOAD_MAGNETLINK %} <a href="{{ site.DOWNLOAD_MAGNETLINK }}" class="magnetlink"></a>{% endif %}<br>
       <a href="/en/version-history">{% translate versionhistory %}</a>
     </p>


### PR DESCRIPTION
Flattr needs to be removed since they do not longer accept Bitcoin. 
See [http://www.reddit.com/r/Bitcoin/comments/27cajy/flattr_removed_bitcoin_support] 

(Also, I've checked it myself)